### PR TITLE
add empty folder to catch the report. Update the final_report target …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,6 @@ pull_image:
 	docker pull evshi/final_report
 
 # Building the report automatically in our container
+.PHONY: final_report
 final_report:
 	docker run -v "/$$(pwd)/final_report":/project/final_report evshi/final_report


### PR DESCRIPTION
…to be a PHONY target (needed because final_report is a file in the directory)

After these changes the report builds and was able to retrieve